### PR TITLE
fix bug queryId

### DIFF
--- a/smartcontract/src/test/java/org/ton/java/smartcontract/integrationtests/TestWalletMultisig.java
+++ b/smartcontract/src/test/java/org/ton/java/smartcontract/integrationtests/TestWalletMultisig.java
@@ -351,7 +351,7 @@ public class TestWalletMultisig extends CommonTest {
         log.info("pubKey0 {}", Utils.bytesToHex(ownerKeyPair.getPublicKey()));
         log.info("pubKey1 {}", Utils.bytesToHex(keyPair2.getPublicKey()));
 
-        BigInteger queryId = BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 5 * 60L, 32));
+        BigInteger queryId = BigInteger.valueOf(Instant.now().getEpochSecond() + 5 * 60L << 32);
 
         Long walletId = new Random().nextLong() & 0xffffffffL;
         log.info("queryId {}, walletId {}", queryId.toString(10), walletId);
@@ -603,7 +603,7 @@ public class TestWalletMultisig extends CommonTest {
         log.info("pubKey4 {}", Utils.bytesToHex(keyPair4.getPublicKey()));
         log.info("pubKey5 {}", Utils.bytesToHex(keyPair5.getPublicKey()));
 
-        BigInteger queryId1 = BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 5 * 60L, 32));
+        BigInteger queryId1 = BigInteger.valueOf(Instant.now().getEpochSecond() + 5 * 60L << 32);
         BigInteger queryId2 = BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 10 * 60L, 32) - 5);
 
         Long walletId = new Random().nextLong() & 0xffffffffL;

--- a/smartcontract/src/test/java/org/ton/java/smartcontract/integrationtests/TestWalletV2Highload.java
+++ b/smartcontract/src/test/java/org/ton/java/smartcontract/integrationtests/TestWalletV2Highload.java
@@ -35,7 +35,7 @@ public class TestWalletV2Highload extends CommonTest {
         Options options = Options.builder()
                 .publicKey(keyPair.getPublicKey())
                 .walletId(42L)
-                .highloadQueryId(BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 5 * 60L, 32))
+                .highloadQueryId(BigInteger.valueOf(Instant.now().getEpochSecond() + 5 * 60L << 32)
                         .add(new BigInteger(String.valueOf(Instant.now().getEpochSecond()))))
                 .wc(0L)
                 .build();
@@ -60,7 +60,7 @@ public class TestWalletV2Highload extends CommonTest {
         Utils.sleep(60, "deploying");
 
         HighloadConfig highloadConfig = HighloadConfig.builder()
-                .queryId(BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 5 * 60L, 32)))
+                .queryId(BigInteger.valueOf(Instant.now().getEpochSecond() + 5 * 60L << 32))
                 .destinations(List.of(
                         Destination.builder()
                                 .address(Address.of("EQAyjRKDnEpTBNfRHqYdnzGEQjdY4KG3gxgqiG3DpDY46u8G"))
@@ -128,7 +128,7 @@ public class TestWalletV2Highload extends CommonTest {
         Options options = Options.builder()
                 .publicKey(keyPair.getPublicKey())
                 .walletId(42L)
-                .highloadQueryId(BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 5 * 60L, 32))
+                .highloadQueryId(BigInteger.valueOf(Instant.now().getEpochSecond() + 5 * 60L << 32)
                         .add(new BigInteger(String.valueOf(Instant.now().getEpochSecond()))))
                 .wc(0L)
                 .build();
@@ -155,7 +155,7 @@ public class TestWalletV2Highload extends CommonTest {
         List<Destination> destinations = generateTargetsWithSameAmountAndSendMode(200, keyPair.getPublicKey());
 
         HighloadConfig highloadConfig = HighloadConfig.builder()
-                .queryId(BigInteger.valueOf((long) Math.pow(Instant.now().getEpochSecond() + 5 * 60L, 32)))
+                .queryId(BigInteger.valueOf(Instant.now().getEpochSecond() + 5 * 60L << 32))
                 .destinations(destinations)
                 .build();
 


### PR DESCRIPTION
This is a bug that causes an exception for sending a second transaction when using a high-performance wallet.

The reason for this is that the wrong queryId is being used, as can be seen in the contract code at https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/highload-wallet-v2-code.fc, which handles the timestamp as The processing of the timestamp is shifted 32 bits to the left, not 32 times, which currently causes it to be out of range for the long type, and the queryId is always the maximum value for the long type, i.e. 9223372036854775807