### PR TITLE
fix: The precision loss issue of new BigDecimal(double/float).

### DIFF
--- a/utils/src/main/java/org/ton/java/utils/Utils.java
+++ b/utils/src/main/java/org/ton/java/utils/Utils.java
@@ -718,7 +718,7 @@ public class Utils {
   }
 
   public static BigInteger toNano(double toncoins, Integer precision) {
-    return new BigDecimal(toncoins).multiply(BigDecimal.TEN.pow(precision)).toBigInteger();
+    return BigDecimal.valueOf(toncoins).multiply(BigDecimal.TEN.pow(precision)).toBigInteger();
   }
 
   public static BigInteger toNano(BigDecimal toncoins, Integer precision) {
@@ -769,7 +769,7 @@ public class Utils {
 
   public static BigInteger toNano(double toncoins) {
     checkToncoinsOverflow(
-        new BigDecimal(toncoins).multiply(BigDecimal.valueOf(BLN1)).toBigInteger());
+        BigDecimal.valueOf(toncoins).multiply(BigDecimal.valueOf(BLN1)).toBigInteger());
     if (BigDecimal.valueOf(toncoins).scale() > 9) {
       throw new Error("Round the number to 9 decimals first");
     }
@@ -778,7 +778,7 @@ public class Utils {
 
   public static BigInteger toNano(float toncoins) {
     checkToncoinsOverflow(
-        new BigDecimal(toncoins).multiply(BigDecimal.valueOf(BLN1)).toBigInteger());
+        BigDecimal.valueOf(toncoins).multiply(BigDecimal.valueOf(BLN1)).toBigInteger());
     if (BigDecimal.valueOf(toncoins).scale() > 9) {
       throw new Error("Round the number to 9 decimals first");
     }


### PR DESCRIPTION
new BigDecimal(double/float) can have precision issues because double is based on the IEEE 754 floating-point standard. It uses binary floating-point representation, and some decimal numbers cannot be represented exactly in binary, leading to precision errors.