### PR TITLE
 Fix deserialization of negative transaction exit codes

### DIFF
--- a/cell/src/main/java/org/ton/java/tlb/types/ComputePhaseVMDetails.java
+++ b/cell/src/main/java/org/ton/java/tlb/types/ComputePhaseVMDetails.java
@@ -63,7 +63,7 @@ public class ComputePhaseVMDetails {
                 .gasLimit(cs.loadVarUInteger(BigInteger.valueOf(3)))
                 .gasCredit(cs.loadBit() ? cs.loadVarUInteger(BigInteger.valueOf(2)) : BigInteger.ZERO)
                 .mode(cs.loadUint(8).intValue())
-                .exitCode(cs.loadUint(32).longValue())
+                .exitCode(cs.loadInt(32).longValue())
                 .exitArg(cs.loadBit() ? cs.loadUint(32).longValue() : 0L)
                 .vMSteps(cs.loadUint(32).longValue())
                 .vMInitStateHash(cs.loadUint(256))


### PR DESCRIPTION
Fix deserialization of negative transaction exit codes.

At the moment `CellSlice#loadUint` method is used for `exitCode` deserialization in `ComputePhaseVMDetails` class. But exit codes can be negative (for examples, [-14](https://docs.ton.org/v3/documentation/tvm/tvm-exit-codes#-14)), so `CellSlice#loadInt` should be used instead as I understand.

Steps to reproduce the problem:
1. Load transaction with negative exit code -14 (for example, [35f6fe4b962fa3412b477e82f489da1fdf3493c79c336da2dac9b44eaefed384](https://testnet.tonviewer.com/transaction/35f6fe4b962fa3412b477e82f489da1fdf3493c79c336da2dac9b44eaefed384)).
2. Check exit code of the loaded transaction using `ComputePhaseVMDetails#getExitCode` method.

Expected result: exit code equals -14.
Actual result:  exit code equals 4294967282.

Unit test example:
```
  @Test
  public void testTonlibTransactionExitCode() {
    Tonlib tonlib = Tonlib.builder()
            .pathToTonlibSharedLib(tonlibPath)
            .ignoreCache(false)
            .testnet(true)
            .build();
    RawTransactions transactions = tonlib.getRawTransactions(
            "kQCAePo20KE2fCceVmDhb09Xylcv4vvfSJCXNe5XACBGcbx0",
            null, null, 10
    );
    String failedTxHash = "35f6fe4b962fa3412b477e82f489da1fdf3493c79c336da2dac9b44eaefed384";
    for (RawTransaction rawTx : transactions.getTransactions()) {
      String txHash = base64ToHexString(rawTx.getTransaction_id().getHash());
      if (!txHash.equals(failedTxHash))
        continue;
      Cell dataCell = CellBuilder.beginCell().fromBocBase64(rawTx.getData()).endCell();
      Transaction tansaction = Transaction.deserialize(CellSlice.beginParse(dataCell));
      TransactionDescriptionOrdinary txDesc = (TransactionDescriptionOrdinary) tansaction.getDescription();
      long exitCode = ((ComputePhaseVM) txDesc.getComputePhase()).getDetails().getExitCode();
      assertThat(exitCode).isEqualTo(-14);
      break;
    }
  }
```