### PR TITLE
Upgrade Apache Commons Lang version to fix vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.neodix42</groupId>
     <artifactId>top</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <modules>
         <module>bitstring</module>
@@ -48,7 +48,7 @@
         <gson.version>2.9.0</gson.version>
         <okhttp.version>4.12.0</okhttp.version>
         <jna.version>5.15.0</jna.version>
-        <lang3.version>3.17.0</lang3.version>
+        <lang3.version>3.18.0</lang3.version>
         <surefire.plugin.version>3.0.0-M7</surefire.plugin.version>
         <maven.compiler.plugin>3.10.1</maven.compiler.plugin>
         <maven.deploy.plugin>3.1.3</maven.deploy.plugin>


### PR DESCRIPTION
Artifacts on Maven Central have a known vulnerability in the Apache Commons Lang dependency.
Vulnerability: [CVE-2025-48924](https://www.cve.org/CVERecord?id=CVE-2025-48924), score: 5.3/10.

Upgrading to the version 3.18.0 should resolve the issue.