### PR TITLE
fix(tl): move rocksdbjni dep from tl to exporter

### DIFF
--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -81,6 +81,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>10.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>9.4.0</version>

--- a/tl/pom.xml
+++ b/tl/pom.xml
@@ -63,11 +63,7 @@
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.rocksdb</groupId>
-            <artifactId>rocksdbjni</artifactId>
-            <version>10.2.1</version>
-        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Previously, `rocksdbjni` was declared in `tl.pom.xml`, but there are zero references to this under `tl/`. `exporter` is actually the module that needs it.